### PR TITLE
Add RogueOS Core skeleton with dual-target build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+RogueOS-Core/build_desktop/
+RogueOS-Core/build_esp32/

--- a/RogueOS-Core/CMakeLists.txt
+++ b/RogueOS-Core/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+project(RogueOSCore)
+
+set(PROFILE "desktop" CACHE STRING "Build profile: desktop or esp32")
+message(STATUS "Selected build profile: ${PROFILE}")
+
+if(PROFILE STREQUAL "desktop")
+    add_subdirectory(desktop)
+elseif(PROFILE STREQUAL "esp32")
+    add_subdirectory(esp32)
+else()
+    message(FATAL_ERROR "Unknown build PROFILE: ${PROFILE}")
+endif()

--- a/RogueOS-Core/desktop/CMakeLists.txt
+++ b/RogueOS-Core/desktop/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16)
+project(RogueOSDesktop)
+
+set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
+
+add_executable(rogueos_desktop
+    ${SRC_DIR}/main_desktop.cpp
+    ${SRC_DIR}/modules/command_router.cpp
+    ${SRC_DIR}/cli/help.cpp
+)
+
+find_package(SDL2 REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LVGL REQUIRED lvgl)
+
+include_directories(${SDL2_INCLUDE_DIRS} ${LVGL_INCLUDE_DIRS} ${SRC_DIR} ${SRC_DIR}/modules ${SRC_DIR}/cli)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+find_package(Boost REQUIRED COMPONENTS system)
+
+add_library(boost_beast INTERFACE)
+target_include_directories(boost_beast INTERFACE /usr/include)
+
+add_custom_target(run_iso
+    COMMAND lb build
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/live-build
+)
+
+target_link_libraries(rogueos_desktop
+    ${SDL2_LIBRARIES}
+    ${LVGL_LIBRARIES}
+    Boost::system
+    Threads::Threads
+)

--- a/RogueOS-Core/esp32/CMakeLists.txt
+++ b/RogueOS-Core/esp32/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+set(IDF_TARGET "esp32")
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(RogueOSESP32)
+
+set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
+
+set(COMPONENT_SRCS
+    ${SRC_DIR}/main_esp32.cpp
+    ${SRC_DIR}/modules/command_router.cpp
+    ${SRC_DIR}/modules/serial_cli.cpp
+    ${SRC_DIR}/cli/help.cpp
+)
+
+set(COMPONENT_ADD_INCLUDEDIRS
+    ${SRC_DIR}
+    ${SRC_DIR}/modules
+    ${SRC_DIR}/cli
+)
+
+idf_component_register(SRCS ${COMPONENT_SRCS} INCLUDE_DIRS ${COMPONENT_ADD_INCLUDEDIRS})

--- a/RogueOS-Core/live-build/auto/build
+++ b/RogueOS-Core/live-build/auto/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+lb build "$@"

--- a/RogueOS-Core/live-build/auto/config
+++ b/RogueOS-Core/live-build/auto/config
@@ -1,0 +1,9 @@
+#!/bin/bash
+lb config \
+    --distribution bookworm \
+    --debian-installer live \
+    --binary-images iso-hybrid \
+    --archive-areas "main contrib non-free non-free-firmware" \
+    --bootappend-live "boot=live components username=rogue" \
+    --linux-flavours amd64 \
+    "$@"

--- a/RogueOS-Core/live-build/config/package-lists/rogueos.list.chroot
+++ b/RogueOS-Core/live-build/config/package-lists/rogueos.list.chroot
@@ -1,0 +1,13 @@
+systemd-sysv
+live-boot
+live-config
+sudo
+network-manager
+xorg
+curl
+git
+bash
+cmake
+libsdl2-dev
+liblvgl-dev
+libboost-system-dev

--- a/RogueOS-Core/src/cli/help.cpp
+++ b/RogueOS-Core/src/cli/help.cpp
@@ -1,0 +1,5 @@
+#include "help.hpp"
+
+std::string cli_help(const std::vector<std::string>&) {
+    return "RogueOS Core Help:\n  help - show this message\n";
+}

--- a/RogueOS-Core/src/cli/help.hpp
+++ b/RogueOS-Core/src/cli/help.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+#include <vector>
+
+std::string cli_help(const std::vector<std::string>& args);

--- a/RogueOS-Core/src/main_desktop.cpp
+++ b/RogueOS-Core/src/main_desktop.cpp
@@ -1,0 +1,85 @@
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+#include <fstream>
+#include <iostream>
+#include <thread>
+#include <SDL2/SDL.h>
+#include <lvgl.h>
+#include <lvgl/lv_drivers/sdl/sdl.h>
+#include "modules/command_router.hpp"
+
+using tcp = boost::asio::ip::tcp;
+namespace http = boost::beast::http;
+namespace websocket = boost::beast::websocket;
+
+std::string run_bash(const std::string& cmd) {
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) return "error\n";
+    std::string output;
+    char buffer[128];
+    while (fgets(buffer, sizeof(buffer), pipe)) {
+        output += buffer;
+    }
+    pclose(pipe);
+    return output;
+}
+
+void session(tcp::socket socket, CommandRouter& router) {
+    try {
+        boost::beast::flat_buffer buffer;
+        http::request<http::string_body> req;
+        http::read(socket, buffer, req);
+
+        if (websocket::is_upgrade(req)) {
+            websocket::stream<tcp::socket> ws{std::move(socket)};
+            ws.accept(req);
+            for (;;) {
+                boost::beast::flat_buffer buff;
+                ws.read(buff);
+                std::string cmd = boost::beast::buffers_to_string(buff.data());
+                std::string result = router.route(cmd);
+                ws.text(true);
+                ws.write(boost::asio::buffer(result));
+            }
+        } else {
+            std::ifstream file("src/ui/webcli/index.html");
+            std::string body((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+            http::response<http::string_body> res{http::status::ok, req.version()};
+            res.set(http::field::content_type, "text/html");
+            res.body() = body;
+            res.prepare_payload();
+            http::write(socket, res);
+        }
+    } catch (std::exception const& e) {
+        std::cerr << "Session error: " << e.what() << std::endl;
+    }
+}
+
+int main() {
+    lv_init();
+    SDL_Init(SDL_INIT_VIDEO);
+    lv_display_t* disp = lv_sdl_window_create(480, 320);
+    (void)disp;
+
+    boost::asio::io_context ioc;
+    tcp::acceptor acceptor{ioc, {tcp::v4(), 8080}};
+
+    CommandRouter router(run_bash);
+
+    std::thread server([&]() {
+        for (;;) {
+            tcp::socket socket{ioc};
+            acceptor.accept(socket);
+            std::thread(session, std::move(socket), std::ref(router)).detach();
+        }
+    });
+
+    while (true) {
+        lv_timer_handler();
+        SDL_Delay(5);
+    }
+
+    server.join();
+    SDL_Quit();
+    return 0;
+}

--- a/RogueOS-Core/src/main_esp32.cpp
+++ b/RogueOS-Core/src/main_esp32.cpp
@@ -1,0 +1,111 @@
+#include "modules/command_router.hpp"
+#include "modules/serial_cli.hpp"
+#include "cli/help.hpp"
+#include "esp_wifi.h"
+#include <Arduino.h>
+#include "esp_event.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "esp_netif.h"
+#include "esp_http_server.h"
+
+static const char *TAG = "RogueOS";
+
+esp_err_t ws_handler(httpd_req_t *req) {
+    httpd_ws_frame_t frame = {};
+    frame.type = HTTPD_WS_TYPE_TEXT;
+    frame.payload = (uint8_t*)"";
+    frame.len = 0;
+    return httpd_ws_recv_frame(req, &frame, 0);
+}
+
+esp_err_t ws_recv(httpd_req_t *req, httpd_ws_frame_t *frame, CommandRouter* router) {
+    std::string cmd(reinterpret_cast<char*>(frame->payload), frame->len);
+    std::string res = router->route(cmd);
+    httpd_ws_frame_t send_pkt;
+    send_pkt.type = HTTPD_WS_TYPE_TEXT;
+    send_pkt.len = res.size();
+    send_pkt.payload = (uint8_t*)res.c_str();
+    return httpd_ws_send_frame(req, &send_pkt);
+}
+
+static esp_err_t ws_handler_wrapper(httpd_req_t *req) {
+    if (req->method == HTTP_GET) {
+        return ws_handler(req);
+    }
+    CommandRouter* router = (CommandRouter*)req->user_ctx;
+    httpd_ws_frame_t frame;
+    memset(&frame, 0, sizeof(httpd_ws_frame_t));
+    frame.type = HTTPD_WS_TYPE_TEXT;
+    httpd_ws_recv_frame(req, &frame, 0);
+    std::vector<uint8_t> buf(frame.len + 1);
+    frame.payload = buf.data();
+    httpd_ws_recv_frame(req, &frame, frame.len);
+    return ws_recv(req, &frame, router);
+}
+
+static httpd_handle_t start_server(CommandRouter* router) {
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+    httpd_handle_t server = NULL;
+    if (httpd_start(&server, &config) == ESP_OK) {
+        extern const unsigned char index_start[] asm("_binary_src_ui_webcli_index_html_start");
+        extern const unsigned char index_end[] asm("_binary_src_ui_webcli_index_html_end");
+        const size_t index_len = index_end - index_start;
+        httpd_uri_t root = {
+            .uri = "/",
+            .method = HTTP_GET,
+            .handler = [](httpd_req_t *req){
+                extern const unsigned char index_start[] asm("_binary_src_ui_webcli_index_html_start");
+                extern const unsigned char index_end[] asm("_binary_src_ui_webcli_index_html_end");
+                const size_t index_len = index_end - index_start;
+                httpd_resp_set_type(req, "text/html");
+                httpd_resp_send(req, (const char*)index_start, index_len);
+                return ESP_OK;
+            },
+            .user_ctx = NULL
+        };
+        httpd_register_uri_handler(server, &root);
+
+        httpd_uri_t ws = {
+            .uri = "/ws",
+            .method = HTTP_GET,
+            .handler = ws_handler_wrapper,
+            .user_ctx = router,
+            .is_websocket = true,
+            .handle_ws_control = NULL,
+        };
+        httpd_register_uri_handler(server, &ws);
+    }
+    return server;
+}
+
+extern "C" void app_main(void) {
+    nvs_flash_init();
+    esp_netif_init();
+    esp_event_loop_create_default();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_wifi_init(&cfg);
+    esp_wifi_set_mode(WIFI_MODE_AP);
+    wifi_config_t wifi_config = {
+        .ap = {
+            .ssid = "RogueOS",
+            .ssid_len = 0,
+            .channel = 1,
+            .password = "password",
+            .max_connection = 4,
+            .authmode = WIFI_AUTH_WPA_WPA2_PSK
+        }
+    };
+    esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
+    esp_wifi_start();
+
+    Serial.begin(115200);
+    SerialCli serial;
+    CommandRouter router([&serial](const std::string& cmd){ return serial.execute(cmd); });
+    start_server(&router);
+
+    while (true) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}

--- a/RogueOS-Core/src/modules/command_router.cpp
+++ b/RogueOS-Core/src/modules/command_router.cpp
@@ -1,0 +1,11 @@
+#include "command_router.hpp"
+#include "../cli/help.hpp"
+
+CommandRouter::CommandRouter(BackendFunc backend) : backend_(backend) {}
+
+std::string CommandRouter::route(const std::string& input) {
+    if (input == "help") {
+        return cli_help({});
+    }
+    return backend_(input);
+}

--- a/RogueOS-Core/src/modules/command_router.hpp
+++ b/RogueOS-Core/src/modules/command_router.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <functional>
+#include <string>
+
+class CommandRouter {
+public:
+    using BackendFunc = std::function<std::string(const std::string&)>;
+    explicit CommandRouter(BackendFunc backend);
+    std::string route(const std::string& input);
+private:
+    BackendFunc backend_;
+};

--- a/RogueOS-Core/src/modules/serial_cli.cpp
+++ b/RogueOS-Core/src/modules/serial_cli.cpp
@@ -1,0 +1,20 @@
+#include "serial_cli.hpp"
+#include <Arduino.h>
+
+std::string SerialCli::execute(const std::string& cmd) {
+    Serial.println(cmd.c_str());
+    Serial.flush();
+    std::string resp;
+    unsigned long start = millis();
+    while (millis() - start < 1000) {
+        while (Serial.available()) {
+            char c = Serial.read();
+            if (c == '\n') {
+                return resp;
+            }
+            resp += c;
+        }
+        delay(10);
+    }
+    return resp;
+}

--- a/RogueOS-Core/src/modules/serial_cli.hpp
+++ b/RogueOS-Core/src/modules/serial_cli.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+class SerialCli {
+public:
+    std::string execute(const std::string& cmd);
+};

--- a/RogueOS-Core/src/ui/webcli/index.html
+++ b/RogueOS-Core/src/ui/webcli/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>RogueOS Web CLI</title>
+<style>
+#terminal{width:100%;height:90vh;border:1px solid #000;overflow:auto;font-family:monospace;}
+</style>
+</head>
+<body>
+<div id="terminal"></div>
+<input id="input" type="text" style="width:100%;" autofocus />
+<script>
+const term = document.getElementById('terminal');
+const input = document.getElementById('input');
+const ws = new WebSocket('ws://'+location.host+'/ws');
+ws.onmessage = e => {
+  term.innerHTML += e.data + '<br>';
+  term.scrollTop = term.scrollHeight;
+};
+input.addEventListener('keydown', e => {
+  if(e.key === 'Enter'){
+    ws.send(input.value);
+    input.value='';
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Set up shared CMake build system with desktop and ESP32 profiles
- Implement command router, help CLI, and web-based terminal reused across targets
- Add live-build configuration for generating a Debian-based bootable ISO

## Testing
- `cmake .. -DPROFILE=desktop` *(fails: The following required packages were not found: lvgl)*
- `lb --version` *(fails: command not found)*
- `cmake .. -DPROFILE=esp32` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a029f2532883329662538360649656